### PR TITLE
修正 Ch5.4 counter_cache 應搭配 .size 使用

### DIFF
--- a/manuscript/chapter-05-4.txt
+++ b/manuscript/chapter-05-4.txt
@@ -114,7 +114,7 @@ end
 
 {::pagebreak :/}
 
-而上了 counter_cache 之後，`<%= group.posts.count %>` 以後執行時，也會優先去找 `posts_count` 裡的值，而不是真的下 MySQL 的 COUNT 去實際算值。
+而上了 counter_cache 之後，`<%= group.posts.size %>` 以後執行時，也會優先去找 `posts_count` 裡的值，而不是真的下 MySQL 的 COUNT 去實際算值。
 
 而加了這個 posts_count 欄位之後，我們就可以修改 index 裡的排序規則變成以文章數量的熱門度 ASC 排序
 


### PR DESCRIPTION
修正第 Ch5.4 關於 counter_cache 的使用

應該使用 `size`，原因是 `count` 總是會下 SQL COUNT query

`size`, `count`, `length` 在這篇有比較說明 http://stackoverflow.com/a/21615375
