### PR TITLE
fix the type of source for members

### DIFF
--- a/manuscript/chapter-04-1.txt
+++ b/manuscript/chapter-04-1.txt
@@ -68,7 +68,7 @@ end
 
 ~~~~~~~~~
   has_many :group_users
-  has_many :members, :through => :group_users, :source => :group 
+  has_many :members, :through => :group_users, :source => :user 
 ~~~~~~~~~
 
 


### PR DESCRIPTION
Members 的 source 應該是 user. 修改前會出現下面類似的錯誤

ActiveRecord::AssociationTypeMismatch at /groups
Group(#70024914946480) expected, got User(#70024912746480)
